### PR TITLE
Extend security context for swagger-ui to /.*

### DIFF
--- a/spring-security-5-oauth-resource/src/main/java/org/baeldung/config/SwaggerConfig.java
+++ b/spring-security-5-oauth-resource/src/main/java/org/baeldung/config/SwaggerConfig.java
@@ -63,7 +63,7 @@ public class SwaggerConfig {
     private SecurityContext securityContext() {
         return SecurityContext.builder()
             .securityReferences(Arrays.asList(new SecurityReference("spring_oauth", scopes())))
-            .forPaths(PathSelectors.regex("/foos.*"))
+            .forPaths(PathSelectors.regex("/.*"))
             .build();
     }
 


### PR DESCRIPTION
Swagger-UI was only able to automatically authenticate endpoints of /foos.*. Every other endpoints would have not be authenticated and yielded

    {   
      "error": "unauthorized",   
      "error_description": "Full authentication is required to access this resource"
    }