### PR TITLE
Resolved issue #293 related to client_secret being passed in POST

### DIFF
--- a/oauth-rest/oauth-authorization-server/src/main/resources/baeldung-realm.json
+++ b/oauth-rest/oauth-authorization-server/src/main/resources/baeldung-realm.json
@@ -442,7 +442,7 @@
     "implicitFlowEnabled" : true,
     "directAccessGrantsEnabled" : true,
     "serviceAccountsEnabled" : false,
-    "publicClient" : false,
+    "publicClient" : true,
     "frontchannelLogout" : false,
     "protocol" : "openid-connect",
     "attributes" : {

--- a/oauth-rest/oauth-ui-authorization-code-angular/src/main/resources/src/app/app.service.ts
+++ b/oauth-rest/oauth-ui-authorization-code-angular/src/main/resources/src/app/app.service.ts
@@ -23,7 +23,6 @@ export class AppService {
     let params = new URLSearchParams();   
     params.append('grant_type','authorization_code');
     params.append('client_id', this.clientId);
-    params.append('client_secret', 'newClientSecret');
     params.append('redirect_uri', this.redirectUri);
     params.append('code',code);
 


### PR DESCRIPTION
As described in the issue #293, current setup is not correct - client secret should never be passed to user browser or mobile app. This is the simplest solution based on disabling requirement for client authentication when obtaining token.