### PR TITLE
Updated Lombok dependency version due to compilation error with Java 17

### DIFF
--- a/oauth-legacy/oauth-microservices/2x/pom.xml
+++ b/oauth-legacy/oauth-microservices/2x/pom.xml
@@ -59,12 +59,11 @@
     </dependencyManagement>
     
     <dependencies>
-
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
+            <version>[1.18.26,)</version>
         </dependency>
-
     </dependencies>
 
     <properties>


### PR DESCRIPTION
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.7.0:compile (default-compile) on project authorization-server-2: Fatal error compiling: java.lang.ExceptionInInitializerError: Unable to make field private com.sun.tools.javac.processing.JavacProcessingEnvironment$DiscoveredProcessors com.sun.tools.javac.processing.JavacProcessingEnvironment.discoveredProcs accessible: module jdk.compiler does not "opens com.sun.tools.javac.processing" to unnamed module @475abed